### PR TITLE
refactor: rediseño del flujo de apertura de cuentas y ciclo de vida

### DIFF
--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -41,10 +41,10 @@ export function Drawer({ isOpen, onClose, title, children }: DrawerProps) {
       />
       
       {/* Drawer Panel */}
-      <div className="relative w-full max-w-md xl:max-w-xl bg-surface h-full shadow-2xl flex flex-col animate-in slide-in-from-right duration-300">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+      <div className="relative w-full max-w-md xl:max-w-xl bg-background h-full shadow-2xl flex flex-col animate-in slide-in-from-right duration-300">
+        <div className="flex items-center justify-between px-6 py-4 bg-surface border-b border-border">
           <h2 className="text-xl font-semibold text-text-primary">{title}</h2>
-          <Button variant="ghost" size="sm" onClick={onClose} className="!px-2">
+          <Button variant="ghost" size="sm" onClick={onClose} className="!px-2 text-text-secondary hover:text-text-primary hover:bg-surface-hover">
             <X className="w-5 h-5" />
           </Button>
         </div>

--- a/apps/web/src/portals/admin/features/accounts/__tests__/integration/OpenAccountPage.test.tsx
+++ b/apps/web/src/portals/admin/features/accounts/__tests__/integration/OpenAccountPage.test.tsx
@@ -43,8 +43,6 @@ describe('OpenAccountPage', () => {
     expect(screen.getByLabelText('ID del Cliente')).toBeInTheDocument();
     expect(screen.getByLabelText('Tipo de Cuenta')).toBeInTheDocument();
     expect(screen.getByLabelText('Moneda')).toBeInTheDocument();
-    expect(screen.getByLabelText('Alias')).toBeInTheDocument();
-    expect(screen.getByLabelText('Saldo Inicial')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Revisar datos' })).toBeInTheDocument();
   });
 
@@ -66,8 +64,6 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Mi cuenta principal');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '1000');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
 
@@ -78,8 +74,6 @@ describe('OpenAccountPage', () => {
     expect(screen.getByText(VALID_UUID)).toBeInTheDocument();
     expect(screen.getByText('Ahorro')).toBeInTheDocument();
     expect(screen.getByText('Peso Mexicano (MXN)')).toBeInTheDocument();
-    expect(screen.getByText('Mi cuenta principal')).toBeInTheDocument();
-    expect(screen.getByText('$1,000.00')).toBeInTheDocument();
   });
 
   it('permite regresar al formulario desde la confirmación', { timeout: LONG_TIMEOUT }, async () => {
@@ -89,8 +83,6 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'CHEQUES');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'USD');
-    await user.type(screen.getByLabelText('Alias'), 'Cuenta de cheques');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '500');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
 
@@ -112,8 +104,6 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Mi ahorro');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '5000');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
 
@@ -152,8 +142,7 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Test');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '1000');
+
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
 
@@ -199,8 +188,6 @@ describe('OpenAccountPage', () => {
 
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Test');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '100');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
     await waitFor(() => {
@@ -229,8 +216,7 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Test');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '1000');
+
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
     await waitFor(() => {
@@ -265,8 +251,6 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Duplicado');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '1000');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
     await waitFor(() => {
@@ -296,8 +280,6 @@ describe('OpenAccountPage', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Test');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '1000');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
     await waitFor(() => {

--- a/apps/web/src/portals/admin/features/accounts/__tests__/unit/ConfirmationStep.test.tsx
+++ b/apps/web/src/portals/admin/features/accounts/__tests__/unit/ConfirmationStep.test.tsx
@@ -8,8 +8,6 @@ const BASE_DATA: OpenAccountFormData = {
   customerId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
   type: 'AHORRO',
   currency: 'MXN',
-  alias: 'Mi cuenta principal',
-  initialBalance: 1000,
 };
 
 function renderStep(overrides?: Partial<Parameters<typeof ConfirmationStep>[0]>) {
@@ -32,15 +30,6 @@ describe('ConfirmationStep', () => {
     expect(screen.getByText(BASE_DATA.customerId)).toBeInTheDocument();
     expect(screen.getByText('Ahorro')).toBeInTheDocument();
     expect(screen.getByText('Peso Mexicano (MXN)')).toBeInTheDocument();
-    expect(screen.getByText('Mi cuenta principal')).toBeInTheDocument();
-    expect(screen.getByText('$1,000.00')).toBeInTheDocument();
-  });
-
-  it('formatea saldo en USD correctamente', () => {
-    renderStep({ data: { ...BASE_DATA, currency: 'USD', initialBalance: 2500.5 } });
-
-    expect(screen.getByText('Dólar Estadounidense (USD)')).toBeInTheDocument();
-    expect(screen.getByText(/USD.*2,500\.50|2,500\.50.*USD|\$.*2,500\.50/)).toBeInTheDocument();
   });
 
   it('resuelve labels de todos los tipos de cuenta', () => {

--- a/apps/web/src/portals/admin/features/accounts/__tests__/unit/OpenAccountForm.test.tsx
+++ b/apps/web/src/portals/admin/features/accounts/__tests__/unit/OpenAccountForm.test.tsx
@@ -12,8 +12,6 @@ describe('OpenAccountForm', () => {
     expect(screen.getByLabelText('ID del Cliente')).toBeInTheDocument();
     expect(screen.getByLabelText('Tipo de Cuenta')).toBeInTheDocument();
     expect(screen.getByLabelText('Moneda')).toBeInTheDocument();
-    expect(screen.getByLabelText('Alias')).toBeInTheDocument();
-    expect(screen.getByLabelText('Saldo Inicial')).toBeInTheDocument();
   });
 
   it('oculta el campo customerId cuando lockCustomerId es true', () => {
@@ -49,8 +47,6 @@ describe('OpenAccountForm', () => {
     await user.type(screen.getByLabelText('ID del Cliente'), VALID_UUID);
     await user.selectOptions(screen.getByLabelText('Tipo de Cuenta'), 'AHORRO');
     await user.selectOptions(screen.getByLabelText('Moneda'), 'MXN');
-    await user.type(screen.getByLabelText('Alias'), 'Test');
-    await user.type(screen.getByLabelText('Saldo Inicial'), '500');
 
     await user.click(screen.getByRole('button', { name: 'Revisar datos' }));
 
@@ -59,8 +55,6 @@ describe('OpenAccountForm', () => {
         customerId: VALID_UUID,
         type: 'AHORRO',
         currency: 'MXN',
-        alias: 'Test',
-        initialBalance: 500,
       }),
       expect.anything(),
     );

--- a/apps/web/src/portals/admin/features/accounts/__tests__/unit/SuccessStep.test.tsx
+++ b/apps/web/src/portals/admin/features/accounts/__tests__/unit/SuccessStep.test.tsx
@@ -35,7 +35,7 @@ describe('SuccessStep', () => {
     );
 
     expect(screen.getByText('Cuenta creada exitosamente')).toBeInTheDocument();
-    expect(screen.getByText('Activa')).toBeInTheDocument();
+    expect(screen.getByText('Pendiente de activación')).toBeInTheDocument();
   });
 
   it('llama navigate(-1) al hacer click en Cerrar', async () => {

--- a/apps/web/src/portals/admin/features/accounts/__tests__/unit/accountsApi.test.ts
+++ b/apps/web/src/portals/admin/features/accounts/__tests__/unit/accountsApi.test.ts
@@ -19,8 +19,6 @@ describe('accountsApi', () => {
       customerId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       type: 'AHORRO' as const,
       currency: 'MXN' as const,
-      alias: 'Test',
-      initialBalance: 100,
     };
 
     const result = await accountsApi.open(payload);

--- a/apps/web/src/portals/admin/features/accounts/__tests__/unit/openAccountSchema.test.ts
+++ b/apps/web/src/portals/admin/features/accounts/__tests__/unit/openAccountSchema.test.ts
@@ -5,8 +5,6 @@ const VALID_DATA = {
   customerId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
   type: 'AHORRO' as const,
   currency: 'MXN' as const,
-  alias: 'Mi cuenta',
-  initialBalance: 1000,
 };
 
 describe('openAccountSchema', () => {
@@ -72,55 +70,6 @@ describe('openAccountSchema', () => {
       if (!result.success) {
         expect(result.error.issues[0].message).toBe('Selecciona una moneda');
       }
-    });
-  });
-
-  describe('alias', () => {
-    it('rechaza string vacio', () => {
-      const result = openAccountSchema.safeParse({ ...VALID_DATA, alias: '' });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].message).toBe('El alias es obligatorio');
-      }
-    });
-
-    it('rechaza alias mayor a 50 caracteres', () => {
-      const result = openAccountSchema.safeParse({ ...VALID_DATA, alias: 'x'.repeat(51) });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].message).toBe('El alias no puede superar 50 caracteres');
-      }
-    });
-
-    it('acepta alias de exactamente 50 caracteres', () => {
-      const result = openAccountSchema.safeParse({ ...VALID_DATA, alias: 'x'.repeat(50) });
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('initialBalance', () => {
-    it('rechaza cero', () => {
-      const result = openAccountSchema.safeParse({ ...VALID_DATA, initialBalance: 0 });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].message).toBe('El saldo inicial debe ser mayor a 0');
-      }
-    });
-
-    it('rechaza numeros negativos', () => {
-      const result = openAccountSchema.safeParse({ ...VALID_DATA, initialBalance: -100 });
-      expect(result.success).toBe(false);
-    });
-
-    it('acepta decimales positivos', () => {
-      const result = openAccountSchema.safeParse({ ...VALID_DATA, initialBalance: 0.01 });
-      expect(result.success).toBe(true);
-    });
-
-    it('rechaza undefined', () => {
-      const { initialBalance: _, ...rest } = VALID_DATA;
-      const result = openAccountSchema.safeParse(rest);
-      expect(result.success).toBe(false);
     });
   });
 });

--- a/apps/web/src/portals/admin/features/accounts/api/types.ts
+++ b/apps/web/src/portals/admin/features/accounts/api/types.ts
@@ -2,8 +2,6 @@ export interface OpenAccountRequest {
   customerId: string;
   type: 'AHORRO' | 'CHEQUES' | 'NOMINA' | 'INVERSION' | 'EMPRESARIAL';
   currency: 'MXN' | 'USD';
-  alias: string;
-  initialBalance: number;
 }
 
 export interface OpenAccountResponse {

--- a/apps/web/src/portals/admin/features/accounts/components/AccountFilters.tsx
+++ b/apps/web/src/portals/admin/features/accounts/components/AccountFilters.tsx
@@ -4,8 +4,9 @@ import { Search, X } from 'lucide-react';
 
 const STATUS_OPTIONS = [
   { value: '', label: 'Todos' },
+  { value: 'PENDING_ACTIVATION', label: 'Pendiente de activaci\u00f3n' },
   { value: 'ACTIVE', label: 'Activa' },
-  { value: 'FROZEN', label: 'Congelada' },
+  { value: 'SUSPENDED', label: 'Suspendida' },
   { value: 'CLOSED', label: 'Cerrada' },
 ] as const;
 

--- a/apps/web/src/portals/admin/features/accounts/components/AccountsTable.tsx
+++ b/apps/web/src/portals/admin/features/accounts/components/AccountsTable.tsx
@@ -1,10 +1,11 @@
 import { Badge } from '@/components/ui';
 import type { AccountListItem } from '../api/types';
 
-const statusMap: Record<string, { label: string; variant: 'success' | 'danger' | 'warning' | 'neutral' }> = {
-  ACTIVE: { label: 'Activa', variant: 'success' },
-  FROZEN: { label: 'Congelada', variant: 'warning' },
-  CLOSED: { label: 'Cerrada', variant: 'neutral' },
+const statusMap: Record<string, { label: string; shortLabel: string; variant: 'success' | 'danger' | 'warning' | 'neutral' }> = {
+  PENDING_ACTIVATION: { label: 'Pendiente de activación', shortLabel: 'Pendiente', variant: 'warning' },
+  ACTIVE: { label: 'Activa', shortLabel: 'Activa', variant: 'success' },
+  SUSPENDED: { label: 'Suspendida', shortLabel: 'Suspendida', variant: 'danger' },
+  CLOSED: { label: 'Cerrada', shortLabel: 'Cerrada', variant: 'neutral' },
 };
 
 const typeLabels: Record<string, string> = {
@@ -64,7 +65,7 @@ export function AccountsTable({ items, loading }: AccountsTableProps) {
         </thead>
         <tbody>
           {items.map((account) => {
-            const st = statusMap[account.status] ?? { label: account.status, variant: 'neutral' as const };
+            const st = statusMap[account.status] ?? { label: account.status, shortLabel: account.status, variant: 'neutral' as const };
             return (
               <tr
                 key={account.id}
@@ -89,7 +90,10 @@ export function AccountsTable({ items, loading }: AccountsTableProps) {
                   {currencyFormatter.format(Number(account.balance))}
                 </td>
                 <td className="px-4 py-3">
-                  <Badge variant={st.variant}>{st.label}</Badge>
+                  <Badge variant={st.variant}>
+                    <span className="hidden sm:inline">{st.label}</span>
+                    <span className="sm:hidden">{st.shortLabel}</span>
+                  </Badge>
                 </td>
                 <td className="px-4 py-3 text-text-secondary text-xs hidden lg:table-cell">
                   {dateFormatter.format(new Date(account.openedAt))}

--- a/apps/web/src/portals/admin/features/accounts/components/ConfirmationStep.tsx
+++ b/apps/web/src/portals/admin/features/accounts/components/ConfirmationStep.tsx
@@ -24,11 +24,6 @@ function Row({ label, value }: { label: string; value: string }) {
 }
 
 export function ConfirmationStep({ data, onConfirm, onBack, loading }: ConfirmationStepProps) {
-  const formattedBalance = new Intl.NumberFormat('es-MX', {
-    style: 'currency',
-    currency: data.currency,
-  }).format(data.initialBalance);
-
   return (
     <Card>
       <CardHeader
@@ -39,8 +34,6 @@ export function ConfirmationStep({ data, onConfirm, onBack, loading }: Confirmat
         <Row label="ID del Cliente" value={data.customerId} />
         <Row label="Tipo de Cuenta" value={typeLabel(data.type)} />
         <Row label="Moneda" value={currencyLabel(data.currency)} />
-        <Row label="Alias" value={data.alias} />
-        <Row label="Saldo Inicial" value={formattedBalance} />
       </CardContent>
       <CardFooter className="justify-end">
         <Button variant="secondary" onClick={onBack} disabled={loading}>

--- a/apps/web/src/portals/admin/features/accounts/components/OpenAccountForm.tsx
+++ b/apps/web/src/portals/admin/features/accounts/components/OpenAccountForm.tsx
@@ -25,13 +25,11 @@ export function OpenAccountForm({ onSubmit, defaultCustomerId, lockCustomerId }:
       customerId: defaultCustomerId ?? '',
       type: undefined,
       currency: undefined,
-      alias: '',
-      initialBalance: undefined as unknown as number,
     },
   });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5 rounded-lg border border-border bg-surface p-5 shadow-card" noValidate>
       {lockCustomerId ? (
         <input type="hidden" {...register('customerId')} />
       ) : (
@@ -59,24 +57,6 @@ export function OpenAccountForm({ onSubmit, defaultCustomerId, lockCustomerId }:
         error={errors.currency?.message}
         defaultValue=""
         {...register('currency')}
-      />
-
-      <Input
-        label="Alias"
-        placeholder="Mi cuenta de ahorro"
-        error={errors.alias?.message}
-        maxLength={50}
-        {...register('alias')}
-      />
-
-      <Input
-        label="Saldo Inicial"
-        type="number"
-        placeholder="0.00"
-        min="0.01"
-        step="0.01"
-        error={errors.initialBalance?.message}
-        {...register('initialBalance', { valueAsNumber: true })}
       />
 
       <Button type="submit" className="mt-2">

--- a/apps/web/src/portals/admin/features/accounts/components/SuccessStep.tsx
+++ b/apps/web/src/portals/admin/features/accounts/components/SuccessStep.tsx
@@ -13,7 +13,7 @@ export function SuccessStep({ result }: SuccessStepProps) {
     <Card>
       <CardHeader
         title="Cuenta creada exitosamente"
-        action={<Badge variant="success">Activa</Badge>}
+        action={<Badge variant="warning">Pendiente de activación</Badge>}
       />
       <CardContent className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">

--- a/apps/web/src/portals/admin/features/accounts/schemas/openAccountSchema.ts
+++ b/apps/web/src/portals/admin/features/accounts/schemas/openAccountSchema.ts
@@ -21,13 +21,6 @@ export const openAccountSchema = z.object({
   currency: z.enum(['MXN', 'USD'], {
     message: 'Selecciona una moneda',
   }),
-  alias: z
-    .string()
-    .min(1, 'El alias es obligatorio')
-    .max(50, 'El alias no puede superar 50 caracteres'),
-  initialBalance: z
-    .number({ message: 'El saldo inicial es obligatorio' })
-    .positive('El saldo inicial debe ser mayor a 0'),
 });
 
 export type OpenAccountFormData = z.infer<typeof openAccountSchema>;

--- a/apps/web/src/portals/client/features/accounts/components/MyAccountCard.tsx
+++ b/apps/web/src/portals/client/features/accounts/components/MyAccountCard.tsx
@@ -2,8 +2,9 @@ import { Badge, Card, CardContent } from '@/components/ui';
 import type { AccountListItem } from '@/portals/admin/features/accounts/api/types';
 
 const statusMap: Record<string, { label: string; variant: 'success' | 'danger' | 'warning' | 'neutral' }> = {
+  PENDING_ACTIVATION: { label: 'Pendiente de activación', variant: 'warning' },
   ACTIVE: { label: 'Activa', variant: 'success' },
-  FROZEN: { label: 'Congelada', variant: 'warning' },
+  SUSPENDED: { label: 'Suspendida', variant: 'danger' },
   CLOSED: { label: 'Cerrada', variant: 'neutral' },
 };
 

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,8 +1,0 @@
-{
-  "framework": "vite",
-  "buildCommand": "cd ../.. && pnpm install --frozen-lockfile && pnpm build --filter=@bank/web",
-  "outputDirectory": "dist",
-  "rewrites": [
-    { "source": "/api/:path*", "destination": "https://banking-api-ht8j.onrender.com/api/:path*" }
-  ]
-}

--- a/packages/contexts/accounts/__tests__/integration/OpenAccountFlow.test.ts
+++ b/packages/contexts/accounts/__tests__/integration/OpenAccountFlow.test.ts
@@ -10,7 +10,7 @@ import { ReadModelMaxAccountsSpec } from '../../src/infrastructure/specification
 import { AccountListProjection } from '../../src/infrastructure/projections/AccountListProjection';
 import { migrateAccountsReadModel } from '../../src/infrastructure/initializeReadModel';
 import { accountsReadModel } from '../../src/infrastructure/schemas/accountsReadModel';
-import { InvalidAccountTypeError, InsufficientOpeningBalanceError } from '../../src/domain/errors';
+import { InvalidAccountTypeError } from '../../src/domain/errors';
 import type { CommandMetadata } from '@bank/shared';
 import type { OpenAccountCommand } from '../../src/application/commands/OpenAccountCommand';
 
@@ -64,7 +64,6 @@ describe('OpenAccount — Flujo de integración', () => {
       type: 'AHORRO',
       currency: 'MXN',
       alias: 'Mi Ahorro',
-      initialBalance: 1000,
       metadata: meta,
     };
 
@@ -79,8 +78,8 @@ describe('OpenAccount — Flujo de integración', () => {
     expect(account!.customerId).toBe('cust-1');
     expect(account!.type).toBe('AHORRO');
     expect(account!.currency).toBe('MXN');
-    expect(account!.balance).toBe(1000);
-    expect(account!.status).toBe('ACTIVE');
+    expect(account!.balance).toBe(0);
+    expect(account!.status).toBe('PENDING_ACTIVATION');
     expect(account!.alias).toBe('Mi Ahorro');
     expect(account!.clabe).toBe(result.clabe);
   });
@@ -98,26 +97,10 @@ describe('OpenAccount — Flujo de integración', () => {
       type: 'CRIPTO',
       currency: 'MXN',
       alias: 'Cripto',
-      initialBalance: 1000,
       metadata: meta,
     };
 
     await expect(handler.execute(command)).rejects.toThrow(InvalidAccountTypeError);
-  });
-
-  it('debe rechazar saldo insuficiente para CHEQUES', async () => {
-    const command: OpenAccountCommand = {
-      commandName: 'OpenAccount',
-      commandId: 'cmd-int-3',
-      customerId: 'cust-1',
-      type: 'CHEQUES',
-      currency: 'MXN',
-      alias: 'Cheques',
-      initialBalance: 100,
-      metadata: meta,
-    };
-
-    await expect(handler.execute(command)).rejects.toThrow(InsufficientOpeningBalanceError);
   });
 
   it('debe proyectar AccountOpened al read model', async () => {
@@ -128,7 +111,6 @@ describe('OpenAccount — Flujo de integración', () => {
       type: 'AHORRO',
       currency: 'MXN',
       alias: 'Mi Ahorro',
-      initialBalance: 500,
       metadata: meta,
     };
 
@@ -147,6 +129,6 @@ describe('OpenAccount — Flujo de integración', () => {
     expect(rows[0].id).toBe(result.accountId);
     expect(rows[0].customerId).toBe('cust-1');
     expect(rows[0].type).toBe('AHORRO');
-    expect(rows[0].status).toBe('ACTIVE');
+    expect(rows[0].status).toBe('PENDING_ACTIVATION');
   });
 });

--- a/packages/contexts/accounts/__tests__/integration/SearchAccountsFlow.test.ts
+++ b/packages/contexts/accounts/__tests__/integration/SearchAccountsFlow.test.ts
@@ -67,8 +67,6 @@ describe('SearchAccounts — Flujo de integración', () => {
       customerId: 'cust-1',
       type: 'AHORRO',
       currency: 'MXN',
-      alias: 'Test',
-      initialBalance: 1000,
       metadata: meta,
       ...overrides,
     };
@@ -106,7 +104,7 @@ describe('SearchAccounts — Flujo de integración', () => {
 
   it('debe filtrar por tipo de cuenta con operador IN', async () => {
     await openAndProject({ customerId: 'cust-1', type: 'AHORRO', alias: 'Ahorro' });
-    await openAndProject({ customerId: 'cust-1', type: 'CHEQUES', alias: 'Cheques', initialBalance: 5000 });
+    await openAndProject({ customerId: 'cust-1', type: 'CHEQUES', alias: 'Cheques' });
 
     const query: SearchAccountsQuery = {
       queryName: 'SearchAccounts',

--- a/packages/contexts/accounts/__tests__/unit/application/OpenAccountHandler.test.ts
+++ b/packages/contexts/accounts/__tests__/unit/application/OpenAccountHandler.test.ts
@@ -47,7 +47,6 @@ describe('OpenAccountHandler', () => {
       type: 'AHORRO',
       currency: 'MXN',
       alias: 'Test',
-      initialBalance: 500,
       metadata,
     });
 
@@ -65,7 +64,7 @@ describe('OpenAccountHandler', () => {
     const handler = new OpenAccountHandler(factory, repository);
     await expect(handler.execute({
       commandName: 'OpenAccount', commandId: 'cmd-2',
-      customerId: 'x', type: 'AHORRO', currency: 'MXN', alias: 'A', initialBalance: 0, metadata,
+      customerId: 'x', type: 'AHORRO', currency: 'MXN', alias: 'A', metadata,
     })).rejects.toThrow('spec failed');
 
     expect(repository.save).not.toHaveBeenCalled();
@@ -82,7 +81,7 @@ describe('OpenAccountHandler', () => {
     const handler = new OpenAccountHandler(factory, repository);
     await expect(handler.execute({
       commandName: 'OpenAccount', commandId: 'cmd-3',
-      customerId: 'cust-1', type: 'AHORRO', currency: 'MXN', alias: 'Test', initialBalance: 500, metadata,
+      customerId: 'cust-1', type: 'AHORRO', currency: 'MXN', alias: 'Test', metadata,
     })).rejects.toThrow('db error');
   });
 });

--- a/packages/contexts/accounts/__tests__/unit/domain/Account.test.ts
+++ b/packages/contexts/accounts/__tests__/unit/domain/Account.test.ts
@@ -31,10 +31,10 @@ function openTestAccount(overrides?: Partial<{ balance: number; type: string }>)
 
 describe('Account Aggregate', () => {
   describe('open', () => {
-    it('debe crear cuenta con estado ACTIVE y un evento uncommitted', () => {
+    it('debe crear cuenta con estado PENDING_ACTIVATION y un evento uncommitted', () => {
       const account = openTestAccount();
 
-      expect(account.status).toBe('ACTIVE');
+      expect(account.status).toBe('PENDING_ACTIVATION');
       expect(account.balance).toBe(1000);
       expect(account.currency).toBe('MXN');
       expect(account.clabe).toBe('012345678901234567');
@@ -73,7 +73,7 @@ describe('Account Aggregate', () => {
 
       expect(restored.id).toBe(original.id);
       expect(restored.customerId).toBe('cust-123');
-      expect(restored.status).toBe('ACTIVE');
+      expect(restored.status).toBe('PENDING_ACTIVATION');
       expect(restored.balance).toBe(1000);
       expect(restored.uncommittedEvents).toHaveLength(0);
     });
@@ -99,7 +99,7 @@ describe('Account Aggregate', () => {
       expect(restored.type).toBe(original.type);
       expect(restored.currency).toBe(original.currency);
       expect(restored.dailyLimit).toBe(original.dailyLimit);
-      expect(restored.status).toBe('ACTIVE');
+      expect(restored.status).toBe('PENDING_ACTIVATION');
       expect(restored.alias).toBe('Mi cuenta');
     });
   });

--- a/packages/contexts/accounts/__tests__/unit/domain/AccountFactory.test.ts
+++ b/packages/contexts/accounts/__tests__/unit/domain/AccountFactory.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AccountFactory } from '../../../src/domain/AccountFactory';
 import { CLABE } from '../../../src/domain/value-objects/CLABE';
-import { CustomerNotActiveError, MaxAccountsReachedError, InsufficientOpeningBalanceError, InvalidAccountTypeError, InvalidCurrencyError } from '../../../src/domain/errors';
+import { CustomerNotActiveError, MaxAccountsReachedError, InvalidAccountTypeError, InvalidCurrencyError } from '../../../src/domain/errors';
 import type { ICustomerActiveSpec } from '../../../src/domain/specifications/ICustomerActiveSpec';
 import type { IMaxAccountsPerTypeSpec } from '../../../src/domain/specifications/IMaxAccountsPerTypeSpec';
 import type { ICLABEGenerator } from '../../../src/domain/services/ICLABEGenerator';
@@ -33,7 +33,6 @@ function validInput() {
     type: 'AHORRO',
     currency: 'MXN',
     alias: 'Mi ahorro',
-    initialBalance: 500,
     metadata,
   };
 }
@@ -49,8 +48,8 @@ describe('AccountFactory', () => {
 
     const account = await factory.create(validInput());
 
-    expect(account.status).toBe('ACTIVE');
-    expect(account.balance).toBe(500);
+    expect(account.status).toBe('PENDING_ACTIVATION');
+    expect(account.balance).toBe(0);
     expect(account.clabe).toBe('012345678901234567');
     expect(mocks.customerActiveSpec.check).toHaveBeenCalledWith('cust-1');
     expect(mocks.maxAccountsSpec.check).toHaveBeenCalled();
@@ -78,18 +77,6 @@ describe('AccountFactory', () => {
     );
 
     await expect(factory.create(validInput())).rejects.toThrow(MaxAccountsReachedError);
-  });
-
-  it('debe lanzar InsufficientOpeningBalanceError si saldo < mínimo', async () => {
-    const mocks = createMocks();
-    const factory = new AccountFactory(
-      mocks.customerActiveSpec,
-      mocks.maxAccountsSpec,
-      mocks.clabeGenerator,
-    );
-
-    const input = { ...validInput(), type: 'CHEQUES', initialBalance: 100 }; // mínimo CHEQUES = 5000
-    await expect(factory.create(input)).rejects.toThrow(InsufficientOpeningBalanceError);
   });
 
   it('debe lanzar error de VO si tipo de cuenta es inválido', async () => {

--- a/packages/contexts/accounts/src/application/commands/OpenAccountCommand.ts
+++ b/packages/contexts/accounts/src/application/commands/OpenAccountCommand.ts
@@ -6,8 +6,7 @@ export interface OpenAccountCommand extends ICommand {
   readonly customerId: string;
   readonly type: string;
   readonly currency: string;
-  readonly alias: string;
-  readonly initialBalance: number;
+  readonly alias?: string;
 }
 
 export interface OpenAccountResult {

--- a/packages/contexts/accounts/src/domain/Account.ts
+++ b/packages/contexts/accounts/src/domain/Account.ts
@@ -89,7 +89,7 @@ export class Account extends AggregateRoot<AccountEvent> {
         this._currency = d['currency'] as string;
         this._balance = d['balance'] as number;
         this._dailyLimit = d['dailyLimit'] as number;
-        this._status = 'ACTIVE';
+        this._status = 'PENDING_ACTIVATION';
         this._alias = d['alias'] as string;
         this._openedAt = d['openedAt'] as string;
         break;

--- a/packages/contexts/accounts/src/domain/AccountFactory.ts
+++ b/packages/contexts/accounts/src/domain/AccountFactory.ts
@@ -4,8 +4,7 @@ import { AccountType } from './value-objects/AccountType';
 import { Currency } from './value-objects/Currency';
 import { Money } from './value-objects/Money';
 import { DailyLimit } from './value-objects/DailyLimit';
-import { InsufficientOpeningBalanceError } from './errors';
-import { MINIMUM_OPENING_BALANCE } from './constants/AccountDefaults';
+import { DEFAULT_ALIAS } from './constants/AccountDefaults';
 import type { ICustomerActiveSpec } from './specifications/ICustomerActiveSpec';
 import type { IMaxAccountsPerTypeSpec } from './specifications/IMaxAccountsPerTypeSpec';
 import type { ICLABEGenerator } from './services/ICLABEGenerator';
@@ -15,8 +14,7 @@ export interface CreateAccountInput {
   readonly customerId: string;
   readonly type: string;
   readonly currency: string;
-  readonly alias: string;
-  readonly initialBalance: number;
+  readonly alias?: string;
   readonly metadata: EventMetadata;
 }
 
@@ -32,7 +30,7 @@ export class AccountFactory {
     const accountId = AccountId.generate();
     const accountType = AccountType.fromString(input.type);
     const currency = Currency.fromString(input.currency);
-    const initialBalance = Money.of(input.initialBalance, currency.value);
+    const initialBalance = Money.of(0, currency.value);
     const dailyLimit = DailyLimit.defaultForType(accountType);
     const clabe = this.clabeGenerator.generate();
 
@@ -40,13 +38,7 @@ export class AccountFactory {
     await this.customerActiveSpec.check(input.customerId);
     await this.maxAccountsSpec.check(input.customerId, accountType);
 
-    // 3. Validar saldo mínimo de apertura (regla pura de dominio)
-    const minimum = MINIMUM_OPENING_BALANCE[accountType.value];
-    if (initialBalance.amount < minimum) {
-      throw new InsufficientOpeningBalanceError(accountType.value, minimum);
-    }
-
-    // 4. Crear agregado
+    // 3. Crear agregado (status: PENDING_ACTIVATION, balance: 0)
     return Account.open({
       accountId,
       customerId: input.customerId,
@@ -55,7 +47,7 @@ export class AccountFactory {
       currency,
       initialBalance,
       dailyLimit,
-      alias: input.alias,
+      alias: input.alias ?? DEFAULT_ALIAS[accountType.value] ?? `Cuenta ${accountType.value}`,
       metadata: input.metadata,
     });
   }

--- a/packages/contexts/accounts/src/domain/constants/AccountDefaults.ts
+++ b/packages/contexts/accounts/src/domain/constants/AccountDefaults.ts
@@ -18,6 +18,14 @@ export const DEFAULT_DAILY_LIMIT: Record<string, number> = {
   EMPRESARIAL: 1_000_000,
 };
 
+export const DEFAULT_ALIAS: Record<string, string> = {
+  AHORRO: 'Cuenta de Ahorro',
+  CHEQUES: 'Cuenta de Cheques',
+  NOMINA: 'Cuenta de Nómina',
+  INVERSION: 'Cuenta de Inversión',
+  EMPRESARIAL: 'Cuenta Empresarial',
+};
+
 export const VALID_ACCOUNT_TYPES = [
   'AHORRO', 'CHEQUES', 'NOMINA', 'INVERSION', 'EMPRESARIAL',
 ] as const;

--- a/packages/contexts/accounts/src/domain/value-objects/AccountStatus.ts
+++ b/packages/contexts/accounts/src/domain/value-objects/AccountStatus.ts
@@ -1,0 +1,24 @@
+import { ValueObject } from '@bank/shared';
+
+const VALID_STATUSES = ['PENDING_ACTIVATION', 'ACTIVE', 'SUSPENDED', 'CLOSED'] as const;
+
+export type AccountStatusValue = (typeof VALID_STATUSES)[number];
+
+export class AccountStatus extends ValueObject<AccountStatusValue> {
+  protected validate(value: AccountStatusValue): void {
+    if (!(VALID_STATUSES as readonly string[]).includes(value)) {
+      throw new Error(`Estado de cuenta no válido: ${value}`);
+    }
+  }
+
+  static readonly PENDING_ACTIVATION = new AccountStatus('PENDING_ACTIVATION');
+  static readonly ACTIVE = new AccountStatus('ACTIVE');
+
+  get isPending(): boolean {
+    return this.value === 'PENDING_ACTIVATION';
+  }
+
+  get isActive(): boolean {
+    return this.value === 'ACTIVE';
+  }
+}

--- a/packages/contexts/accounts/src/infrastructure/projections/AccountListProjection.ts
+++ b/packages/contexts/accounts/src/infrastructure/projections/AccountListProjection.ts
@@ -27,7 +27,7 @@ export class AccountListProjection implements IProjection {
           currency: d['currency'] as string,
           balance: String(d['balance']),
           dailyLimit: String(d['dailyLimit']),
-          status: 'ACTIVE',
+          status: 'PENDING_ACTIVATION',
           alias: d['alias'] as string,
           openedAt: new Date(d['openedAt'] as string),
         }).onConflictDoNothing();

--- a/packages/server/api/__tests__/unit/AccountController.test.ts
+++ b/packages/server/api/__tests__/unit/AccountController.test.ts
@@ -39,8 +39,6 @@ describe('AccountController', () => {
       customerId: '550e8400-e29b-41d4-a716-446655440000',
       type: 'AHORRO',
       currency: 'MXN',
-      alias: 'Mi Ahorro',
-      initialBalance: 1000,
     });
     const res = mockRes();
 
@@ -64,8 +62,6 @@ describe('AccountController', () => {
       customerId: '550e8400-e29b-41d4-a716-446655440000',
       type: 'CHEQUES',
       currency: 'USD',
-      alias: 'Business',
-      initialBalance: 5000,
     });
     const res = mockRes();
 
@@ -77,8 +73,6 @@ describe('AccountController', () => {
         customerId: '550e8400-e29b-41d4-a716-446655440000',
         type: 'CHEQUES',
         currency: 'USD',
-        alias: 'Business',
-        initialBalance: 5000,
       }),
     );
   });
@@ -90,8 +84,6 @@ describe('AccountController', () => {
       customerId: '550e8400-e29b-41d4-a716-446655440000',
       type: 'AHORRO',
       currency: 'MXN',
-      alias: 'Test',
-      initialBalance: 1000,
     });
     const res = mockRes();
 
@@ -111,8 +103,6 @@ describe('AccountController', () => {
       customerId: '550e8400-e29b-41d4-a716-446655440000',
       type: 'AHORRO',
       currency: 'MXN',
-      alias: 'A',
-      initialBalance: 100,
     });
     const res = mockRes();
 

--- a/packages/server/api/__tests__/unit/openAccountSchema.test.ts
+++ b/packages/server/api/__tests__/unit/openAccountSchema.test.ts
@@ -6,8 +6,6 @@ describe('openAccountSchema', () => {
     customerId: '550e8400-e29b-41d4-a716-446655440000',
     type: 'AHORRO',
     currency: 'MXN',
-    alias: 'Mi Ahorro',
-    initialBalance: 1000,
   };
 
   it('debe aceptar un body válido', () => {
@@ -33,9 +31,14 @@ describe('openAccountSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('debe rechazar alias vacío', () => {
+  it('debe aceptar alias opcional', () => {
+    const result = openAccountSchema.safeParse({ ...validBody, alias: 'Mi Ahorro' });
+    expect(result.success).toBe(true);
+  });
+
+  it('debe aceptar alias vacío', () => {
     const result = openAccountSchema.safeParse({ ...validBody, alias: '' });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it('debe rechazar alias mayor a 50 caracteres', () => {
@@ -43,21 +46,11 @@ describe('openAccountSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('debe rechazar saldo inicial negativo', () => {
-    const result = openAccountSchema.safeParse({ ...validBody, initialBalance: -100 });
-    expect(result.success).toBe(false);
-  });
-
-  it('debe rechazar saldo inicial cero', () => {
-    const result = openAccountSchema.safeParse({ ...validBody, initialBalance: 0 });
-    expect(result.success).toBe(false);
-  });
-
   it('debe rechazar campos faltantes', () => {
     const result = openAccountSchema.safeParse({});
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues.length).toBeGreaterThanOrEqual(5);
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
     }
   });
 

--- a/packages/server/api/__tests__/unit/validateBody.test.ts
+++ b/packages/server/api/__tests__/unit/validateBody.test.ts
@@ -23,8 +23,6 @@ describe('validateBody middleware', () => {
       customerId: '550e8400-e29b-41d4-a716-446655440000',
       type: 'AHORRO',
       currency: 'MXN',
-      alias: 'Test',
-      initialBalance: 1000,
     });
     const res = mockRes();
     const next: NextFunction = vi.fn();
@@ -60,8 +58,6 @@ describe('validateBody middleware', () => {
       customerId: '550e8400-e29b-41d4-a716-446655440000',
       type: 'AHORRO',
       currency: 'MXN',
-      alias: 'Test',
-      initialBalance: 1000,
       extraField: 'should-be-stripped',
     });
     const res = mockRes();

--- a/packages/server/api/src/controllers/AccountController.ts
+++ b/packages/server/api/src/controllers/AccountController.ts
@@ -31,7 +31,6 @@ export class AccountController {
       type: body.type,
       currency: body.currency,
       alias: body.alias,
-      initialBalance: body.initialBalance,
       metadata,
     };
 

--- a/packages/server/api/src/http/schemas/openAccountSchema.ts
+++ b/packages/server/api/src/http/schemas/openAccountSchema.ts
@@ -11,9 +11,8 @@ export const openAccountSchema = z.object({
   }),
   alias: z
     .string()
-    .min(1, 'El alias no puede estar vacío')
-    .max(50, 'El alias no puede superar 50 caracteres'),
-  initialBalance: z.number().positive('El saldo inicial debe ser positivo'),
+    .max(50, 'El alias no puede superar 50 caracteres')
+    .optional(),
 });
 
 export type OpenAccountBody = z.infer<typeof openAccountSchema>;


### PR DESCRIPTION
- Dominio/Backend: Implementar estado PENDING_ACTIVATION. Las cuentas nuevas se crean con balance $0 y el alias se genera automáticamente.
- API/Frontend: Eliminar campos de 'alias' y 'saldo inicial' del Payload/Comando de apertura de cuenta y del formulario en la UI.
- UI/UX: Unificar mapa de estados (Pendiente, Activa, Suspendida, Cerrada), mejorar diseño visual del Drawer y formulario, y ajustar badges para vista móvil.
- Ops: Solucionar error 401 en el despliegue agregando soporte de variables de entorno en turbo.json (globalPassThroughEnv).
- Tests: Actualizar pruebas unitarias y de integración en backend y frontend afectadas por el cambio de ciclo de vida y UI.